### PR TITLE
Escape commas as special characters in job names

### DIFF
--- a/veeam_microsoft365.sh
+++ b/veeam_microsoft365.sh
@@ -220,7 +220,7 @@ veeamJobsUrl=$(curl -X GET --header "Accept:application/json" --header "Authoriz
 
 declare -i arrayJobs=0
 for id in $(echo "$veeamJobsUrl" | jq -r '.[].id'); do
-    nameJob=$(echo "$veeamJobsUrl" | jq --raw-output ".[$arrayJobs].name" | awk '{gsub(/ /,"\\ ");print}')
+    nameJob=$(echo "$veeamJobsUrl" | jq --raw-output ".[$arrayJobs].name" | awk '{gsub(/ /,"\\ "); gsub(/,/, "\\,"); print}')
     idJob=$(echo "$veeamJobsUrl" | jq --raw-output ".[$arrayJobs].id")
 
     # Backup Job Sessions


### PR DESCRIPTION
Should fix https://github.com/jorgedlcruz/veeam-backup-for-microsoft365-grafana/issues/13 - an error message is currently received when a job name contains a comma.

Commas need to be escaped as per the docs: https://docs.influxdata.com/influxdb/cloud/reference/syntax/line-protocol/#special-characters